### PR TITLE
Use HTTPS to avoid possible MITM attacks

### DIFF
--- a/embrava/EmbravaConnectForWindows/updateinfo.json
+++ b/embrava/EmbravaConnectForWindows/updateinfo.json
@@ -1,6 +1,6 @@
 {
 	"version": "5.2.37",
-	"installerUrl": "http://bit.ly/2VWTMFZ",
+	"installerUrl": "https://bit.ly/2VWTMFZ",
 	"installerAlternateUrl": "https://cdn2.hubspot.net/hubfs/5409396/Installers/EmbravaConnect_v5.2.37.zip",
 	"releaseDate": "05.March.2020"
 }


### PR DESCRIPTION
HTTP should not be used as any part of automatic software updates to avoid any possibility of MITM attacks. In this case if the traffic can be intercepted then an attacker could redirect to a different download and if the updater doesn't check the certificate on the .exe or if it doesn't securely handle the unzipping of the .zip file then an attacker with MITM access could exploit the update process. Even if the updater does those things, HTTPS should be used as an extra layer of defense. 